### PR TITLE
feat: pre-commit/pre-push linting with husky

### DIFF
--- a/site/.husky/pre-commit
+++ b/site/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd site && npm run lint

--- a/site/.husky/pre-push
+++ b/site/.husky/pre-push
@@ -1,0 +1,1 @@
+cd site && npm run lint

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.1.6",
+        "husky": "^8.0.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -3002,6 +3003,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prepare": "cd .. && husky install site/.husky",
+    "postinstall": "chmod +x .husky/pre-push && chmod +x .husky/pre-commit"
   },
   "dependencies": {
     "@vercel/analytics": "^1.4.1",
@@ -31,6 +33,7 @@
     "eslint-config-next": "15.1.6",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "husky": "^8.0.0"
   }
 }


### PR DESCRIPTION
This PR is concerned with enforcing running `npm run lint` on the `/site` directory every time a commit is made locally or a push is made to remote to enforce checking for ESLint syntax violations and to prevent failed builds.

Husky is a light-weight library to avoid writing raw Git hooks and dealing with hook installation manually. 

A similar consideration for running prettier on relevant files is to be made.

![image](https://github.com/user-attachments/assets/0cf88f88-8c56-4619-93ed-ba999333f3fd)
