### PR TITLE
feat: urbanist font support

### DIFF
--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -68,5 +64,8 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  html {
+    font-family: var(--font-urbanist), system-ui, sans-serif;
   }
 }

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -21,8 +21,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${urbanist.variable} antialiased`}>
+    <html lang="en" className={`${urbanist.variable} antialiased)`}>
+      <body>
         <Toaster />
         <Analytics />
         <SpeedInsights />

--- a/site/tailwind.config.ts
+++ b/site/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
 
 export default {
     darkMode: ["class"],
@@ -9,6 +10,9 @@ export default {
   ],
   theme: {
   	extend: {
+			fontFamily: {
+  			sans: ["var(--font-urbanist)", ...fontFamily.sans]
+  		},
   		colors: {
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',


### PR DESCRIPTION
Branches off https://github.com/altverseweb3/altverse/pull/9 (needs rebase after/if it is merged)

- Add Urbanist font to theme
- Integrates it into theme configs in case we will want more fonts going forward (for mono, specific sections, etc.)

![image](https://github.com/user-attachments/assets/7422be2d-a6ef-408b-9741-f835b13c5ca5)
