### PR TITLE
feat: added basic wallet methods for metamask

### DIFF
--- a/site/src/app/dapp/bridge/page.tsx
+++ b/site/src/app/dapp/bridge/page.tsx
@@ -1,6 +1,3 @@
-
 export default function BridgeModal() {
-    return (
-      <div>bridge</div>
-    )
-  }
+  return <div>bridge</div>;
+}

--- a/site/src/app/dapp/layout.tsx
+++ b/site/src/app/dapp/layout.tsx
@@ -1,16 +1,14 @@
-import { SiteHeader } from "@/components/layout/SiteHeader"
+import { SiteHeader } from "@/components/layout/SiteHeader";
 
 export default function DAppLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <div className="min-h-screen">
       <SiteHeader />
-      <main className="container mx-auto px-4 py-8">
-        {children}
-      </main>
+      <main className="container mx-auto px-4 py-8">{children}</main>
     </div>
-  )
+  );
 }

--- a/site/src/app/dapp/page.tsx
+++ b/site/src/app/dapp/page.tsx
@@ -1,6 +1,3 @@
-
 export default function DashboardPage() {
-  return (
-    <div>dApp</div>
-  )
+  return <div>dApp</div>;
 }

--- a/site/src/app/dapp/swap/page.tsx
+++ b/site/src/app/dapp/swap/page.tsx
@@ -1,6 +1,3 @@
-
 export default function SwapModal() {
-    return (
-      <div>swap</div>
-    )
-  }
+  return <div>swap</div>;
+}

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,16 +1,15 @@
-import Link from "next/link"
-
+import Link from "next/link";
 
 export default function Home() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center">
       <h1 className="text-4xl font-bold mb-8">Altverse</h1>
-      <Link 
-        href="/dapp" 
+      <Link
+        href="/dapp"
         className="px-6 py-3 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
       >
         Get started
       </Link>
     </main>
-  )
+  );
 }

--- a/site/src/components/layout/MainNav.tsx
+++ b/site/src/components/layout/MainNav.tsx
@@ -1,35 +1,37 @@
-'use client'
+"use client";
 
-import { useRouter, usePathname } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { TAB_CONFIG } from "@/config/tabs"
-import { Tab } from "@/types/tab"
+import { useRouter, usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { TAB_CONFIG } from "@/config/tabs";
+import { Tab } from "@/types/tab";
 
 export function MainNav() {
-  const router = useRouter()
-  const pathname = usePathname()
-  
+  const router = useRouter();
+  const pathname = usePathname();
+
   // Get current tab from URL path
-  const currentTab = pathname.split('/').pop() as Tab
+  const currentTab = pathname.split("/").pop() as Tab;
 
   return (
     <nav className="flex items-center space-x-4">
-      {(Object.entries(TAB_CONFIG) as [Tab, typeof TAB_CONFIG[Tab]][]).map(([value, config]) => (
-        <Button
-          key={value}
-          variant={currentTab === value ? "default" : "ghost"}
-          disabled={config.disabled}
-          title={config.disabledMessage}
-          className="text-sm font-medium transition-colors"
-          onClick={() => {
-            if (!config.disabled) {
-              router.push(`/dapp/${value}`)
-            }
-          }}
-        >
-          {config.label}
-        </Button>
-      ))}
+      {(Object.entries(TAB_CONFIG) as [Tab, (typeof TAB_CONFIG)[Tab]][]).map(
+        ([value, config]) => (
+          <Button
+            key={value}
+            variant={currentTab === value ? "default" : "ghost"}
+            disabled={config.disabled}
+            title={config.disabledMessage}
+            className="text-sm font-medium transition-colors"
+            onClick={() => {
+              if (!config.disabled) {
+                router.push(`/dapp/${value}`);
+              }
+            }}
+          >
+            {config.label}
+          </Button>
+        ),
+      )}
     </nav>
-  )
+  );
 }

--- a/site/src/components/layout/SiteHeader.tsx
+++ b/site/src/components/layout/SiteHeader.tsx
@@ -5,12 +5,45 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "../ui/button";
 import { useState } from "react";
+import useWeb3Store from "@/store/web3Store";
+import {
+  connectMetamask,
+  disconnectMetamask,
+  truncateAddress,
+} from "@/utils/walletMethods";
+import { toast } from "sonner";
 
 export function SiteHeader() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const activeWallet = useWeb3Store((state) => state.activeWallet);
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  const handleMetamaskButtonClick = async () => {
+    if (activeWallet) {
+      try {
+        await disconnectMetamask();
+      } catch (error) {
+        toast("Failed to disconnect wallet.");
+        console.error("Failed to disconnect wallet: ", error);
+      }
+    } else {
+      console.log("Starting wallet connection...");
+      try {
+        const walletInfo = await connectMetamask();
+        console.log("Wallet connection result:", walletInfo);
+
+        if (!walletInfo) {
+          toast("Failed to connect wallet.");
+          console.error("Failed to connect wallet");
+        }
+      } catch (error) {
+        toast("Failed to connect wallet.");
+        console.error("Failed to connect wallet:", error);
+      }
+    }
   };
 
   return (
@@ -77,8 +110,15 @@ export function SiteHeader() {
             </svg>
           </Button>
 
-          <Button variant="outline" size="sm" className="whitespace-nowrap">
-            Connect Wallet
+          <Button
+            variant="outline"
+            size="sm"
+            className="whitespace-nowrap"
+            onClick={handleMetamaskButtonClick}
+          >
+            {activeWallet
+              ? truncateAddress(activeWallet.address)
+              : "Connect Metamask"}
           </Button>
         </div>
       </div>

--- a/site/src/components/ui/button.tsx
+++ b/site/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
@@ -30,27 +30,27 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/site/src/config/tabs.ts
+++ b/site/src/config/tabs.ts
@@ -1,31 +1,31 @@
 import { Tab } from "@/types/tab";
 
 interface TabConfig {
-    label: string;
-    disabled?: boolean;
-    disabledMessage?: string;
-  }
-  
-  export const TAB_CONFIG: Record<Tab, TabConfig> = {
-    swap: {
-      label: "Swap"
-    },
-    bridge: {
-      label: "Bridge"
-    },
-    stake: {
-      label: "Stake",
-      disabled: true,
-      disabledMessage: "Coming soon"
-    },
-    borrow: {
-      label: "Borrow",
-      disabled: true,
-      disabledMessage: "Coming soon"
-    },
-    dashboard: {
-      label: "Dashboard",
-      disabled: true,
-      disabledMessage: "Coming soon"
-    }
-  };
+  label: string;
+  disabled?: boolean;
+  disabledMessage?: string;
+}
+
+export const TAB_CONFIG: Record<Tab, TabConfig> = {
+  swap: {
+    label: "Swap",
+  },
+  bridge: {
+    label: "Bridge",
+  },
+  stake: {
+    label: "Stake",
+    disabled: true,
+    disabledMessage: "Coming soon",
+  },
+  borrow: {
+    label: "Borrow",
+    disabled: true,
+    disabledMessage: "Coming soon",
+  },
+  dashboard: {
+    label: "Dashboard",
+    disabled: true,
+    disabledMessage: "Coming soon",
+  },
+};

--- a/site/src/types/wallet.ts
+++ b/site/src/types/wallet.ts
@@ -1,18 +1,8 @@
-import type { MetaMaskInpageProvider } from '@metamask/providers';
-
-// Union type for different provider types
-export type WalletProvider = 
-  | MetaMaskInpageProvider 
-  // Add other provider types as needed, e.g.:
-  // | WalletConnectProvider when we get there
-  ;
-
 export interface WalletInfo {
   type: WalletType; // Static Enum to type/identify the wallet
   name: string; // human-readable name of the wallet e.g. "MetaMask"
   icon?: string; // will be an svg imported from /public
   address: string; // users wallet address, can seamlessly change during the session
-  provider: WalletProvider; // web3 provider e.g. window.ethereum - leaving as `any` type for future proofing, may lock down later
   chainId: number; // the currently connected chain on the wallet
 }
 

--- a/site/src/types/window.d.ts
+++ b/site/src/types/window.d.ts
@@ -1,0 +1,10 @@
+import type { MetaMaskInpageProvider } from "@metamask/providers";
+
+declare global {
+  interface Window {
+    ethereum?: MetaMaskInpageProvider;
+  }
+}
+
+// Need to include an export for TypeScript to treat this as a module
+export {};

--- a/site/src/utils/walletMethods.ts
+++ b/site/src/utils/walletMethods.ts
@@ -1,0 +1,97 @@
+import { WalletInfo, WalletType } from "@/types/wallet";
+
+import useWeb3Store from "@/store/web3Store";
+
+export async function connectMetamask(): Promise<WalletInfo | null> {
+  if (!window.ethereum) {
+    throw new Error("Metamask not installed");
+  }
+
+  try {
+    const accounts = await window.ethereum.request<string[]>({
+      method: "eth_requestAccounts",
+    });
+
+    const chainId = await window.ethereum.request<string>({
+      method: "eth_chainId",
+    });
+
+    if (!accounts || accounts.length === 0 || !accounts[0]) {
+      throw new Error("No accounts found");
+    }
+
+    const address = accounts[0];
+
+    if (!chainId) {
+      throw new Error("No chainId found");
+    }
+
+    const walletInfo: WalletInfo = {
+      type: WalletType.METAMASK,
+      name: "MetaMask",
+      address,
+      chainId: parseInt(chainId, 16),
+    };
+
+    // Update the store immediately on connection
+    const store = useWeb3Store.getState();
+    store.addWallet(walletInfo);
+
+    // Set up account change listener
+    window.ethereum.on("accountsChanged", (accounts: unknown) => {
+      const store = useWeb3Store.getState();
+      const newAccounts = accounts as string[];
+      if (!newAccounts || newAccounts.length === 0) {
+        // MetaMask was locked or disconnected
+        store.removeWallet(WalletType.METAMASK);
+      } else {
+        // Account was switched
+        store.updateWalletAddress(WalletType.METAMASK, newAccounts[0]);
+      }
+    });
+
+    // Set up chain change listener
+    window.ethereum.on("chainChanged", (chainId: unknown) => {
+      const store = useWeb3Store.getState();
+      store.updateWalletChainId(
+        WalletType.METAMASK,
+        parseInt(chainId as string, 16),
+      );
+    });
+
+    // Set up disconnect listener
+    window.ethereum.on("disconnect", () => {
+      const store = useWeb3Store.getState();
+      store.removeWallet(WalletType.METAMASK);
+    });
+
+    return walletInfo;
+  } catch (error) {
+    console.error("Error connecting to MetaMask:", error);
+    return null;
+  }
+}
+
+export async function disconnectMetamask(): Promise<void> {
+  try {
+    if (window.ethereum) {
+      // Remove all event listeners
+      window.ethereum.removeAllListeners("accountsChanged");
+      window.ethereum.removeAllListeners("chainChanged");
+      window.ethereum.removeAllListeners("disconnect");
+
+      // Update the store
+      const store = useWeb3Store.getState();
+      store.removeWallet(WalletType.METAMASK);
+    }
+  } catch (error) {
+    console.error("Error disconnecting from MetaMask:", error);
+    throw error;
+  }
+}
+
+// used to display truncated wallet address
+export const truncateAddress = (address: string) => {
+  if (!address) return "";
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};


### PR DESCRIPTION
- prettified a bunch of files that somehow missed the husky hook
- added `walletMethods.ts` which contains basic metamask wallet functions
- updated `WalletInfo` interface to remove provider property, as it can be inferred from the wallet type and is not a storage object in zustand
- declared global `window.ethereum` reference to allow global access to the command