### PR TITLE
feat: generalised swap page components for reusability

### DIFF
--- a/site/src/app/(dapp)/swap/page.tsx
+++ b/site/src/app/(dapp)/swap/page.tsx
@@ -1,87 +1,51 @@
 "use client";
 
-import React, { useState, ReactNode } from "react";
-import { Card, CardContent } from "@/components/ui/Card";
-import { Button } from "@/components/ui/Button";
-import { Settings, Coins } from "lucide-react";
-import { SelectTokenButton } from "@/components/ui/SelectTokenButton";
-import { SelectChainButton } from "@/components/ui/SelectChainButton";
+import React, { useState } from "react";
+import { Settings } from "lucide-react";
+import { AssetBox } from "@/components/ui/AssetBox";
+import { TokenInputGroup } from "@/components/ui/TokenInputGroup";
+import { SwapInterface } from "@/components/ui/SwapInterface";
 
-interface SwapBoxProps {
-  children: ReactNode;
-}
-
-const SwapBox: React.FC<SwapBoxProps> = ({ children }) => (
-  <div className="bg-zinc-900 rounded-lg pt-2 px-4 pb-4 w-full h-[160px] flex flex-col">
-    {children}
-  </div>
-);
-
-const SwapComponent: React.FC = () => {
+const SwapComponent = () => {
   const [amount, setAmount] = useState<string>("");
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setAmount(e.target.value);
   };
 
+  const settingsButton = (
+    <button>
+      <Settings className="h-4 w-4 text-zinc-400 mr-2" />
+    </button>
+  );
+
   return (
-    <div className="flex items-start justify-center bg-background p-4 pt-6">
-      <Card className="w-full max-w-[520px] sm:max-w-md bg-zinc-900/50 border-zinc-800">
-        <CardContent className="space-y-4 p-6">
-          {/* Send Box */}
-          <SwapBox>
-            <div className="flex justify-between items-center">
-              <span className="text-zinc-400 text-md">send</span>
-              <div className="flex items-center gap-2">
-                <button>
-                  <Settings className="h-4 w-4 text-zinc-400 mr-2" />
-                </button>
-                <SelectChainButton />
-              </div>
-            </div>
-            <div className="flex justify-between items-start gap-4 mt-auto">
-              <SelectTokenButton variant="amber" />
-              <div className="flex-1 flex flex-col items-end">
-                <input
-                  type="number"
-                  value={amount}
-                  onChange={handleAmountChange}
-                  placeholder="0"
-                  className="w-full bg-transparent text-3xl focus:outline-none text-right"
-                />
-                <span className="text-zinc-400 text-sm">$0.00</span>
-              </div>
-            </div>
-          </SwapBox>
+    <div className="flex items-start justify-center min-h-screen bg-background p-4 pt-[10vh]">
+      <SwapInterface
+        actionButton={{
+          text: "swap",
+          iconName: "Coins",
+          disabled: !amount || amount === "0",
+        }}
+      >
+        {/* Send Box */}
+        <AssetBox
+          title="send"
+          settingsComponent={settingsButton}
+          showChainSelector={true}
+        >
+          <TokenInputGroup
+            variant="amber"
+            amount={amount}
+            onChange={handleAmountChange}
+          />
+        </AssetBox>
 
-          {/* Receive Box */}
-          <SwapBox>
-            <div className="flex justify-between items-center">
-              <span className="text-zinc-400 text-md">receive</span>
-              <div className="flex items-center gap-2">
-                <SelectChainButton />
-              </div>
-            </div>
-            <div className="flex justify-between items-start gap-4 mt-auto">
-              <SelectTokenButton variant="sky" />
-              <div className="flex-1 flex flex-col items-end">
-                <input
-                  type="number"
-                  placeholder="0"
-                  className="w-full bg-transparent text-3xl focus:outline-none text-right"
-                  readOnly
-                />
-                <span className="text-zinc-400 text-sm">$0.00</span>
-              </div>
-            </div>
-          </SwapBox>
-
-          <Button className="w-full bg-amber-500/25 hover:bg-amber-600/50 text-amber-500 border-amber-500 border-[0.5px] rounded-lg leading-zero text-lg">
-            <Coins className="h-6 w-6 mr-2" />
-            swap
-          </Button>
-        </CardContent>
-      </Card>
+        {/* Receive Box */}
+        <AssetBox title="receive" showSettings={false}>
+          <TokenInputGroup variant="sky" amount="" readOnly={true} />
+        </AssetBox>
+      </SwapInterface>
     </div>
   );
 };

--- a/site/src/components/ui/AssetBox.tsx
+++ b/site/src/components/ui/AssetBox.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from "react";
+import { SelectChainButton } from "@/components/ui/SelectChainButton";
+
+interface AssetBoxProps {
+  title: string;
+  children: ReactNode;
+  showSettings?: boolean;
+  settingsComponent?: ReactNode;
+  showChainSelector?: boolean;
+  additionalHeaderControls?: ReactNode;
+}
+
+export function AssetBox({
+  title,
+  children,
+  showSettings = false,
+  settingsComponent = null,
+  showChainSelector = true,
+  additionalHeaderControls = null,
+}: AssetBoxProps) {
+  return (
+    <div className="bg-zinc-900 rounded-lg pt-2 px-4 pb-4 w-full h-[160px] flex flex-col">
+      <div className="flex justify-between items-center">
+        <span className="text-zinc-400 text-md">{title}</span>
+        <div className="flex items-center gap-2">
+          {showSettings && settingsComponent}
+          {additionalHeaderControls}
+          {showChainSelector && <SelectChainButton />}
+        </div>
+      </div>
+      <div className="mt-auto">{children}</div>
+    </div>
+  );
+}
+
+export default AssetBox;

--- a/site/src/components/ui/BrandedButton.tsx
+++ b/site/src/components/ui/BrandedButton.tsx
@@ -1,13 +1,18 @@
 import React, { ButtonHTMLAttributes } from "react";
 import { Button } from "@/components/ui/Button";
-import * as LucideIcons from "lucide-react";
+import { Coins, Link, ArrowRightLeft, Repeat, Network } from "lucide-react";
 
-// Type for all available Lucide icon names
-type LucideIconName = keyof typeof LucideIcons;
+// Use a string literal type for the icon names
+type AvailableIconName =
+  | "Coins"
+  | "Link"
+  | "ArrowRightLeft"
+  | "Repeat"
+  | "Network";
 
 // Props interface extending HTML button attributes
 interface BrandedButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  iconName: LucideIconName;
+  iconName: AvailableIconName;
   buttonText: string;
   className?: string;
 }
@@ -18,8 +23,14 @@ export function BrandedButton({
   className = "",
   ...props
 }: BrandedButtonProps) {
-  // Type assertion to ensure TypeScript understands this is a valid component
-  const IconComponent = LucideIcons[iconName] as React.ElementType;
+  // Get the correct icon component directly in the component
+  const IconComponent = {
+    Coins,
+    Link,
+    ArrowRightLeft,
+    Repeat,
+    Network,
+  }[iconName];
 
   return (
     <Button

--- a/site/src/components/ui/BrandedButton.tsx
+++ b/site/src/components/ui/BrandedButton.tsx
@@ -1,0 +1,35 @@
+import React, { ButtonHTMLAttributes } from "react";
+import { Button } from "@/components/ui/Button";
+import * as LucideIcons from "lucide-react";
+
+// Type for all available Lucide icon names
+type LucideIconName = keyof typeof LucideIcons;
+
+// Props interface extending HTML button attributes
+interface BrandedButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  iconName: LucideIconName;
+  buttonText: string;
+  className?: string;
+}
+
+export function BrandedButton({
+  iconName,
+  buttonText,
+  className = "",
+  ...props
+}: BrandedButtonProps) {
+  // Type assertion to ensure TypeScript understands this is a valid component
+  const IconComponent = LucideIcons[iconName] as React.ElementType;
+
+  return (
+    <Button
+      className={`w-full bg-amber-500/25 hover:bg-amber-600/50 text-amber-500 border-amber-500 border-[0.5px] rounded-lg leading-zero text-lg ${className}`}
+      {...props}
+    >
+      <IconComponent className="h-6 w-6 mr-2" />
+      {buttonText}
+    </Button>
+  );
+}
+
+export default BrandedButton;

--- a/site/src/components/ui/SelectChainButton.tsx
+++ b/site/src/components/ui/SelectChainButton.tsx
@@ -1,11 +1,21 @@
+import React from "react";
 import { ChevronDown } from "lucide-react";
+import Image from "next/image";
 
 export const SelectChainButton: React.FC = () => (
   <button
     type="button"
     className="flex items-center space-x-2 px-1 py-1.5 rounded-lg bg-[#627eea]"
   >
-    <img src="/tokens/mono/ETH.svg" alt="Ethereum" className="w-5 h-5" />
+    <Image
+      src="/tokens/mono/ETH.svg"
+      alt="Ethereum"
+      width={20}
+      height={20}
+      className="w-5 h-5"
+    />
     <ChevronDown className="h-3 w-3 text-white" />
   </button>
 );
+
+export default SelectChainButton;

--- a/site/src/components/ui/SelectTokenButton.tsx
+++ b/site/src/components/ui/SelectTokenButton.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from "lucide-react";
 
-interface TokenButtonProps {
+export interface TokenButtonProps {
   variant: "amber" | "sky";
 }
 

--- a/site/src/components/ui/SwapInterface.tsx
+++ b/site/src/components/ui/SwapInterface.tsx
@@ -1,16 +1,20 @@
 import React, { ReactNode } from "react";
 import { Card, CardContent } from "@/components/ui/Card";
 import { BrandedButton } from "@/components/ui/BrandedButton";
-import * as LucideIcons from "lucide-react";
 
-// Get the type for Lucide icon names
-type LucideIconName = keyof typeof LucideIcons;
+// Use a string literal type for the icon names
+type AvailableIconName =
+  | "Coins"
+  | "Link"
+  | "ArrowRightLeft"
+  | "Repeat"
+  | "Network";
 
 interface SwapInterfaceProps {
   children: ReactNode;
   actionButton: {
     text: string;
-    iconName: LucideIconName;
+    iconName: AvailableIconName;
     onClick?: () => void;
     disabled?: boolean;
   };

--- a/site/src/components/ui/SwapInterface.tsx
+++ b/site/src/components/ui/SwapInterface.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode } from "react";
+import { Card, CardContent } from "@/components/ui/Card";
+import { BrandedButton } from "@/components/ui/BrandedButton";
+import * as LucideIcons from "lucide-react";
+
+// Get the type for Lucide icon names
+type LucideIconName = keyof typeof LucideIcons;
+
+interface SwapInterfaceProps {
+  children: ReactNode;
+  actionButton: {
+    text: string;
+    iconName: LucideIconName;
+    onClick?: () => void;
+    disabled?: boolean;
+  };
+  className?: string;
+}
+
+export function SwapInterface({
+  children,
+  actionButton,
+  className = "",
+}: SwapInterfaceProps) {
+  return (
+    <Card
+      className={`w-full max-w-[520px] sm:max-w-md bg-zinc-900/50 border-zinc-800 ${className}`}
+    >
+      <CardContent className="space-y-4 p-6">
+        {children}
+        <BrandedButton
+          buttonText={actionButton.text}
+          iconName={actionButton.iconName}
+          onClick={actionButton.onClick}
+          disabled={actionButton.disabled}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SwapInterface;

--- a/site/src/components/ui/TokenAmountInput.tsx
+++ b/site/src/components/ui/TokenAmountInput.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface TokenAmountInputProps {
+  amount: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  dollarValue?: string;
+  readOnly?: boolean;
+  placeholder?: string;
+}
+
+export function TokenAmountInput({
+  amount,
+  onChange,
+  dollarValue = "$0.00",
+  readOnly = false,
+  placeholder = "0",
+}: TokenAmountInputProps) {
+  return (
+    <div className="flex-1 flex flex-col items-end">
+      <input
+        type="number"
+        value={amount}
+        onChange={onChange}
+        placeholder={placeholder}
+        className="w-full bg-transparent text-3xl focus:outline-none text-right"
+        readOnly={readOnly}
+      />
+      <span className="text-zinc-400 text-sm">{dollarValue}</span>
+    </div>
+  );
+}
+
+export default TokenAmountInput;

--- a/site/src/components/ui/TokenInputGroup.tsx
+++ b/site/src/components/ui/TokenInputGroup.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { SelectTokenButton } from "@/components/ui/SelectTokenButton";
+import { TokenAmountInput } from "@/components/ui/TokenAmountInput";
+
+interface TokenInputGroupProps {
+  variant: "amber" | "sky";
+  amount: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  dollarValue?: string;
+  readOnly?: boolean;
+}
+
+export function TokenInputGroup({
+  variant,
+  amount,
+  onChange,
+  dollarValue = "$0.00",
+  readOnly = false,
+}: TokenInputGroupProps) {
+  return (
+    <div className="flex justify-between items-start gap-4 w-full">
+      <SelectTokenButton variant={variant} />
+      <TokenAmountInput
+        amount={amount}
+        onChange={onChange}
+        dollarValue={dollarValue}
+        readOnly={readOnly}
+      />
+    </div>
+  );
+}
+
+export default TokenInputGroup;


### PR DESCRIPTION
Added a number of new generalised reusable components that will allow us to build the other pages like Lego.
- `AssetBox.tsx`: the top/bottom parts of the swap component, including the chain selector and settings button
- `BrandedButton.tsx`: the iconic "swap" button that has the text and LucideIcon name as props
- `SwapInterface.tsx`: the entire outline of the Swap page that could be reused for the other pages. Only specifics the outer container and the swap button.
- `TokenAmountInput.tsx`: contains the token input and the dollar value.
- `TokenInputGroup.tsx`: combines the Token Input component (above) with the token selection - this will likely be reused in many other components.

Also changed the use of the `<img />` element to `<Image />` from `next/image` as suggested by `npm run lint`.