### PR TITLE
feat: added footer with social icons

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-fast-marquee": "^1.6.5",
+        "react-social-icons": "^6.22.0",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
@@ -53,6 +54,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4599,8 +4612,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4740,7 +4752,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5601,6 +5612,55 @@
         }
       }
     },
+    "node_modules/react-social-icons": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-6.22.0.tgz",
+      "integrity": "sha512-+KN3yL61+oPR9BqHvMRin7gwfYnzLPFsiyHTTJ6g+AwO5v8rfJ/qWUv3TZqeqInfGmKWobpnLOp4pm48HHaK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.8",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "peerDependencies": {
+        "react": "15.x.x || 16.x.x || 17.x.x || 18.x.x",
+        "react-dom": "15.x.x || 16.x.x || 17.x.x || 18.x.x"
+      }
+    },
+    "node_modules/react-social-icons/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-social-icons/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-social-icons/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -5678,6 +5738,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/site/package.json
+++ b/site/package.json
@@ -26,6 +26,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-fast-marquee": "^1.6.5",
+    "react-social-icons": "^6.22.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/site/src/app/(dapp)/layout.tsx
+++ b/site/src/app/(dapp)/layout.tsx
@@ -1,4 +1,5 @@
 import { SiteHeader } from "@/components/layout/SiteHeader";
+import { SiteFooter } from "@/components/layout/SiteFooter";
 
 export default function DAppLayout({
   children,
@@ -6,9 +7,10 @@ export default function DAppLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen">
+    <div className="flex min-h-screen flex-col">
       <SiteHeader />
-      <main className="container mx-auto px-4 py-8">{children}</main>
+      <main className="container mx-auto flex-1 px-4 py-8">{children}</main>
+      <SiteFooter />
     </div>
   );
 }

--- a/site/src/app/(dapp)/swap/page.tsx
+++ b/site/src/app/(dapp)/swap/page.tsx
@@ -25,7 +25,7 @@ const SwapComponent: React.FC = () => {
   };
 
   return (
-    <div className="flex items-start justify-center min-h-screen bg-background p-4 pt-[10vh]">
+    <div className="flex items-start justify-center bg-background p-4 pt-6">
       <Card className="w-full max-w-[520px] sm:max-w-md bg-zinc-900/50 border-zinc-800">
         <CardContent className="space-y-4 p-6">
           {/* Send Box */}

--- a/site/src/components/layout/SiteFooter.tsx
+++ b/site/src/components/layout/SiteFooter.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { SocialIcon } from "react-social-icons";
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t bg-background">
+      <div className="mx-auto flex h-12 items-center px-4">
+        <p className="text-xs sm:text-sm text-muted-foreground">
+          © {new Date().getFullYear()} Altverse. All rights reserved.
+        </p>
+
+        <div className="ml-auto flex items-center gap-1">
+          <SocialIcon
+            url="https://discord.gg/xDMCtNJCEv"
+            bgColor="#0A0A0B"
+            fgColor="#A6A6A9"
+            style={{ height: 36, width: 36 }}
+          />
+
+          <SocialIcon
+            url="https://x.com/altverseweb3"
+            bgColor="#0A0A0B"
+            fgColor="#A6A6A9"
+            style={{ height: 36, width: 36 }}
+          />
+
+          <SocialIcon
+            url="https://t.me/altverse"
+            bgColor="#0A0A0B"
+            fgColor="#A6A6A9"
+            style={{ height: 36, width: 36 }}
+          />
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/site/src/components/layout/SiteHeader.tsx
+++ b/site/src/components/layout/SiteHeader.tsx
@@ -55,7 +55,7 @@ export function SiteHeader() {
 
   return (
     <header className="bg-background sticky top-0 z-40 w-full border-b">
-      <div className="flex h-16 items-center px-4">
+      <div className="flex h-14 items-center px-4">
         {/* Logo and Nav Container */}
         <div className="flex items-center gap-8">
           <Link href="/" className="flex items-center gap-3">


### PR DESCRIPTION
Added a footer containing all rights reserved message and social icons (telegram group not yet created).

Uses [react-social-icons](https://www.npmjs.com/package/react-social-icons) as lucide does not provide all the required logos, and this package automatically detects the required logo based on the link.

![Screenshot 2025-02-25 at 8 10 49 pm](https://github.com/user-attachments/assets/ffafec63-0e87-4cf4-b0c0-cf47eda2ef7c)

![Screenshot 2025-02-25 at 8 11 09 pm](https://github.com/user-attachments/assets/83dd259e-a3f7-47d1-bc6f-b27eb508cb18)
