### PR TITLE
feat: chain selection is now stored in zustand

### DIFF
--- a/site/src/app/(dapp)/bridge/page.tsx
+++ b/site/src/app/(dapp)/bridge/page.tsx
@@ -1,14 +1,33 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Settings } from "lucide-react";
 import { AssetBox } from "@/components/ui/AssetBox";
 import { TokenInputGroup } from "@/components/ui/TokenInputGroup";
 import { SwapInterface } from "@/components/ui/SwapInterface";
 import { TokenSwitch } from "@/components/ui/TokenSwitch";
+import { isStoreHydrated, useHydrationCheck } from "@/utils/chainMethods";
 
-const BridgeComponent = () => {
+const BridgeComponent: React.FC = () => {
   const [amount, setAmount] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(!isStoreHydrated());
+
+  // Get hydration check function
+  const checkHydration = useHydrationCheck();
+
+  // Check if the store has hydrated and update loading state
+  useEffect(() => {
+    // If already hydrated, skip the check
+    if (!isLoading) return;
+
+    // Otherwise, check for hydration
+    const waitForHydration = async () => {
+      await checkHydration();
+      setIsLoading(false);
+    };
+
+    waitForHydration();
+  }, [isLoading, checkHydration]);
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setAmount(e.target.value);
@@ -19,6 +38,44 @@ const BridgeComponent = () => {
       <Settings className="h-5 w-5 text-zinc-400 hover:text-zinc-50 transition-colors" />
     </button>
   );
+
+  // If the store isn't hydrated yet, show a minimal loading state
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">
+        <div className="w-full max-w-md opacity-50">
+          {/* Same UI structure, but with reduced opacity until hydration completes */}
+          <SwapInterface
+            actionButton={{
+              text: "Loading...",
+              iconName: "Cable",
+              disabled: true,
+            }}
+          >
+            <AssetBox title="send" showSettings={true} showChainSelector={true}>
+              <TokenInputGroup
+                variant="amber"
+                amount=""
+                showSelectToken={true}
+              />
+            </AssetBox>
+            <AssetBox
+              title="receive"
+              showSettings={false}
+              showChainSelector={true}
+            >
+              <TokenInputGroup
+                variant="sky"
+                amount=""
+                readOnly={true}
+                showSelectToken={false}
+              />
+            </AssetBox>
+          </SwapInterface>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">
@@ -36,6 +93,7 @@ const BridgeComponent = () => {
             showSettings={true}
             settingsComponent={settingsButton}
             showChainSelector={true}
+            boxType="source"
           >
             <TokenInputGroup
               variant="amber"
@@ -48,7 +106,12 @@ const BridgeComponent = () => {
           <TokenSwitch />
 
           {/* Receive Box */}
-          <AssetBox title="receive" showSettings={false}>
+          <AssetBox
+            title="receive"
+            showSettings={false}
+            showChainSelector={true}
+            boxType="destination"
+          >
             <TokenInputGroup
               variant="sky"
               amount=""

--- a/site/src/app/(dapp)/bridge/page.tsx
+++ b/site/src/app/(dapp)/bridge/page.tsx
@@ -1,33 +1,14 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Settings } from "lucide-react";
 import { AssetBox } from "@/components/ui/AssetBox";
 import { TokenInputGroup } from "@/components/ui/TokenInputGroup";
 import { SwapInterface } from "@/components/ui/SwapInterface";
 import { TokenSwitch } from "@/components/ui/TokenSwitch";
-import { isStoreHydrated, useHydrationCheck } from "@/utils/chainMethods";
 
 const BridgeComponent: React.FC = () => {
   const [amount, setAmount] = useState<string>("");
-  const [isLoading, setIsLoading] = useState(!isStoreHydrated());
-
-  // Get hydration check function
-  const checkHydration = useHydrationCheck();
-
-  // Check if the store has hydrated and update loading state
-  useEffect(() => {
-    // If already hydrated, skip the check
-    if (!isLoading) return;
-
-    // Otherwise, check for hydration
-    const waitForHydration = async () => {
-      await checkHydration();
-      setIsLoading(false);
-    };
-
-    waitForHydration();
-  }, [isLoading, checkHydration]);
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setAmount(e.target.value);
@@ -38,44 +19,6 @@ const BridgeComponent: React.FC = () => {
       <Settings className="h-5 w-5 text-zinc-400 hover:text-zinc-50 transition-colors" />
     </button>
   );
-
-  // If the store isn't hydrated yet, show a minimal loading state
-  if (isLoading) {
-    return (
-      <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">
-        <div className="w-full max-w-md opacity-50">
-          {/* Same UI structure, but with reduced opacity until hydration completes */}
-          <SwapInterface
-            actionButton={{
-              text: "Loading...",
-              iconName: "Cable",
-              disabled: true,
-            }}
-          >
-            <AssetBox title="send" showSettings={true} showChainSelector={true}>
-              <TokenInputGroup
-                variant="amber"
-                amount=""
-                showSelectToken={true}
-              />
-            </AssetBox>
-            <AssetBox
-              title="receive"
-              showSettings={false}
-              showChainSelector={true}
-            >
-              <TokenInputGroup
-                variant="sky"
-                amount=""
-                readOnly={true}
-                showSelectToken={false}
-              />
-            </AssetBox>
-          </SwapInterface>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">

--- a/site/src/app/(dapp)/swap/page.tsx
+++ b/site/src/app/(dapp)/swap/page.tsx
@@ -1,33 +1,14 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Settings } from "lucide-react";
 import { AssetBox } from "@/components/ui/AssetBox";
 import { TokenInputGroup } from "@/components/ui/TokenInputGroup";
 import { SwapInterface } from "@/components/ui/SwapInterface";
 import { TokenSwitch } from "@/components/ui/TokenSwitch";
-import { isStoreHydrated, useHydrationCheck } from "@/utils/chainMethods";
 
 const SwapComponent: React.FC = () => {
   const [amount, setAmount] = useState<string>("");
-  const [isLoading, setIsLoading] = useState(!isStoreHydrated());
-
-  // Get hydration check function
-  const checkHydration = useHydrationCheck();
-
-  // Check if the store has hydrated and update loading state
-  useEffect(() => {
-    // If already hydrated, skip the check
-    if (!isLoading) return;
-
-    // Otherwise, check for hydration
-    const waitForHydration = async () => {
-      await checkHydration();
-      setIsLoading(false);
-    };
-
-    waitForHydration();
-  }, [isLoading, checkHydration]);
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setAmount(e.target.value);
@@ -38,44 +19,6 @@ const SwapComponent: React.FC = () => {
       <Settings className="h-5 w-5 text-zinc-400 hover:text-zinc-50 transition-colors" />
     </button>
   );
-
-  // If the store isn't hydrated yet, show a minimal loading state
-  if (isLoading) {
-    return (
-      <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">
-        <div className="w-full max-w-md opacity-50">
-          {/* Same UI structure, but with reduced opacity until hydration completes */}
-          <SwapInterface
-            actionButton={{
-              text: "Loading...",
-              iconName: "Coins",
-              disabled: true,
-            }}
-          >
-            <AssetBox title="send" showSettings={true} showChainSelector={true}>
-              <TokenInputGroup
-                variant="amber"
-                amount=""
-                showSelectToken={true}
-              />
-            </AssetBox>
-            <AssetBox
-              title="receive"
-              showSettings={false}
-              showChainSelector={true}
-            >
-              <TokenInputGroup
-                variant="sky"
-                amount=""
-                readOnly={true}
-                showSelectToken={true}
-              />
-            </AssetBox>
-          </SwapInterface>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">

--- a/site/src/components/ui/AssetBox.tsx
+++ b/site/src/components/ui/AssetBox.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode } from "react";
 import { SelectChainButton } from "@/components/ui/SelectChainButton";
-import { Chain, defaultChain } from "@/config/chains";
+import { Chain } from "@/config/chains";
 
 interface AssetBoxProps {
   title: string;
@@ -8,12 +8,10 @@ interface AssetBoxProps {
   showSettings?: boolean;
   settingsComponent?: ReactNode;
   showChainSelector?: boolean;
-  additionalHeaderControls?: ReactNode;
   className?: string;
-  onChainChange?: (chain: Chain) => void;
-  initialChain?: Chain;
   displayChainName?: boolean;
   availableChains?: Chain[];
+  boxType?: "source" | "destination";
 }
 
 export function AssetBox({
@@ -22,22 +20,11 @@ export function AssetBox({
   showSettings = false,
   settingsComponent = null,
   showChainSelector = true,
-  additionalHeaderControls = null,
   className = "",
-  onChainChange,
-  initialChain = defaultChain,
   displayChainName = false,
   availableChains,
+  boxType,
 }: AssetBoxProps) {
-  const [selectedChain, setSelectedChain] = useState<Chain>(initialChain);
-
-  const handleChainSelect = (chain: Chain) => {
-    setSelectedChain(chain);
-    if (onChainChange) {
-      onChainChange(chain);
-    }
-  };
-
   return (
     <div
       className={`bg-zinc-900 rounded-[6px] pt-[10px] px-[1.5rem] pb-[1.5rem] w-full min-h-[100px] sm:min-h-[120px] md:min-h-[140px] flex flex-col ${className}`}
@@ -46,13 +33,11 @@ export function AssetBox({
         <span className="text-zinc-50/50 text-[1.2rem]">{title}</span>
         <div className="flex items-center gap-2 sm:gap-3">
           {showSettings && settingsComponent}
-          {additionalHeaderControls}
           {showChainSelector && (
             <SelectChainButton
-              selectedChain={selectedChain}
-              onChainSelect={handleChainSelect}
               displayName={displayChainName}
               chainsToShow={availableChains}
+              storeType={boxType}
             />
           )}
         </div>

--- a/site/src/components/ui/ConnectWalletModal.tsx
+++ b/site/src/components/ui/ConnectWalletModal.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/Button";
 import { connectMetamask } from "@/utils/walletMethods";
 import { toast } from "sonner";
-import { WalletInfo, WalletType } from "@/types/wallet";
+import { WalletInfo, WalletType } from "@/types/web3";
 import { cn } from "@/lib/utils";
 
 type WalletOption = {

--- a/site/src/components/ui/SelectChainButton.tsx
+++ b/site/src/components/ui/SelectChainButton.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/DropdownMenu";
-import { Chain, chainList, defaultChain } from "@/config/chains";
+import { Chain, chainList, defaultSourceChain } from "@/config/chains";
 import useWeb3Store from "@/store/web3Store";
 
 interface SelectChainButtonProps {
@@ -33,12 +33,12 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
     (state) => state.setDestinationChain,
   );
 
-  // Determine the chain to display (from props or store)
+  // Determine the chain to display (from store)
   const selectedChain = storeType
     ? storeType === "source"
       ? sourceChain
       : destinationChain
-    : propSelectedChain || defaultChain;
+    : propSelectedChain || defaultSourceChain;
 
   // State for the icon currently being displayed
   const [displayedChain, setDisplayedChain] = useState<Chain>(selectedChain);
@@ -69,16 +69,6 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
       propOnChainSelect(chain);
     }
   };
-
-  useEffect(() => {
-    // Debug log
-    if (storeType) {
-      console.log(
-        `SelectChainButton (${storeType}) rendering with chain:`,
-        selectedChain.name,
-      );
-    }
-  }, [selectedChain, storeType]);
 
   // When selectedChain changes, animate the icon change:
   useEffect(() => {

--- a/site/src/components/ui/SelectChainButton.tsx
+++ b/site/src/components/ui/SelectChainButton.tsx
@@ -8,23 +8,41 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/DropdownMenu";
 import { Chain, chainList, defaultChain } from "@/config/chains";
+import useWeb3Store from "@/store/web3Store";
 
 interface SelectChainButtonProps {
   selectedChain?: Chain;
   onChainSelect?: (chain: Chain) => void;
   displayName?: boolean;
   chainsToShow?: Chain[];
+  storeType?: "source" | "destination"; // Optional prop for Zustand store integration
 }
 
 export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
-  selectedChain = defaultChain,
-  onChainSelect,
+  selectedChain: propSelectedChain,
+  onChainSelect: propOnChainSelect,
   displayName = false,
   chainsToShow = chainList,
+  storeType,
 }) => {
-  // State for the icon currently being displayed.
+  // Get store values and setters if storeType is provided
+  const sourceChain = useWeb3Store((state) => state.sourceChain);
+  const destinationChain = useWeb3Store((state) => state.destinationChain);
+  const setSourceChain = useWeb3Store((state) => state.setSourceChain);
+  const setDestinationChain = useWeb3Store(
+    (state) => state.setDestinationChain,
+  );
+
+  // Determine the chain to display (from props or store)
+  const selectedChain = storeType
+    ? storeType === "source"
+      ? sourceChain
+      : destinationChain
+    : propSelectedChain || defaultChain;
+
+  // State for the icon currently being displayed
   const [displayedChain, setDisplayedChain] = useState<Chain>(selectedChain);
-  // State for the icon's opacity.
+  // State for the icon's opacity
   const [opacity, setOpacity] = useState(1);
   // State for background transition
   const [showRipple, setShowRipple] = useState(false);
@@ -36,6 +54,31 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
   const [fontColor, setFontColor] = useState(
     selectedChain.fontColor || "#FFFFFF",
   );
+
+  // Handle chain selection based on whether we're using the store or props
+  const handleChainSelect = (chain: Chain) => {
+    if (storeType) {
+      // Update the store
+      if (storeType === "source") {
+        setSourceChain(chain);
+      } else {
+        setDestinationChain(chain);
+      }
+    } else if (propOnChainSelect) {
+      // Use the prop callback (old behavior)
+      propOnChainSelect(chain);
+    }
+  };
+
+  useEffect(() => {
+    // Debug log
+    if (storeType) {
+      console.log(
+        `SelectChainButton (${storeType}) rendering with chain:`,
+        selectedChain.name,
+      );
+    }
+  }, [selectedChain, storeType]);
 
   // When selectedChain changes, animate the icon change:
   useEffect(() => {
@@ -110,12 +153,13 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
 
           {/* Chain Icon with opacity transition - Fixed dimensions */}
           <div
-            className="relative z-10 flex-shrink-0"
+            className="relative z-10 flex-shrink-0 transition-all duration-300"
             style={{
               width: "18px",
               height: "18px",
               opacity,
-              transition: "opacity 300ms ease",
+              transition: "opacity 300ms ease, transform 300ms ease",
+              transform: isChanging ? "scale(0.9)" : "scale(1)",
             }}
           >
             <Image
@@ -175,7 +219,7 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
         {chainsToShow.map((chain) => (
           <DropdownMenuItem
             key={chain.id}
-            onClick={() => onChainSelect && onChainSelect(chain)}
+            onClick={() => handleChainSelect(chain)}
             className="chain-dropdown-item cursor-pointer"
           >
             <div

--- a/site/src/config/chains.ts
+++ b/site/src/config/chains.ts
@@ -140,16 +140,19 @@ export const chains: Record<string, Chain> = {
 export const chainList: Chain[] = Object.values(chains);
 
 // Default chain
-export const defaultChain: Chain = chains.ethereum;
+export const defaultSourceChain: Chain = chains.ethereum;
+export const defaultDestinationChain: Chain = chains.polygon;
 
 // Get chain by ID
 export const getChainById = (id: string): Chain => {
-  return chains[id] || defaultChain;
+  return chains[id] || defaultSourceChain;
 };
 
 // Get chain by chain ID (numeric)
 export const getChainByChainId = (chainId: number): Chain => {
-  return chainList.find((chain) => chain.chainId === chainId) || defaultChain;
+  return (
+    chainList.find((chain) => chain.chainId === chainId) || defaultSourceChain
+  );
 };
 
 // Get testnet chains

--- a/site/src/store/web3Store.ts
+++ b/site/src/store/web3Store.ts
@@ -1,229 +1,176 @@
 import { create } from "zustand";
-import {
-  persist,
-  createJSONStorage,
-  PersistOptions,
-  StateStorage,
-} from "zustand/middleware";
-import { StateCreator, StoreApi } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import { WalletInfo, Web3StoreState, WalletType } from "@/types/web3";
-import { Chain, defaultChain } from "@/config/chains";
-import React from "react";
+import {
+  Chain,
+  defaultSourceChain,
+  defaultDestinationChain,
+} from "@/config/chains";
 
-// Extend the store state to include hydration status
-interface ExtendedWeb3StoreState extends Web3StoreState {
-  // Used by useStoreHydration hook to track hydration status
-  _hasHydrated?: boolean;
-}
+// Create the store with standard persist middleware
+const useWeb3Store = create<Web3StoreState>()(
+  persist(
+    (set) => ({
+      connectedWallets: [],
+      activeWallet: null,
 
-// Helper type for the persisted state - everything except _hasHydrated
-type PersistedState = Omit<ExtendedWeb3StoreState, "_hasHydrated">;
+      // Chain selection state
+      sourceChain: defaultSourceChain,
+      destinationChain: defaultDestinationChain,
 
-// Using Zustand's built-in types instead of defining our own
-
-// Create a custom version of persist middleware that handles SSR/hydration
-const createPersistMiddleware =
-  <T extends ExtendedWeb3StoreState>(config: StateCreator<T, [], []>) =>
-  (
-    set: StoreApi<T>["setState"],
-    get: StoreApi<T>["getState"],
-    api: StoreApi<T>,
-  ) => {
-    const isSSR = typeof window === "undefined";
-
-    // Configure persistence options
-    const persistOptions: PersistOptions<T, PersistedState> = {
-      name: "altverse-storage-web3",
-      storage: createJSONStorage(() =>
-        isSSR
-          ? ({
-              getItem: () => Promise.resolve(null),
-              setItem: () => Promise.resolve(),
-              removeItem: () => Promise.resolve(),
-            } as StateStorage)
-          : localStorage,
-      ),
-      version: 1,
-      partialize: (state): PersistedState => {
-        // Create a shallow copy of state without _hasHydrated
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { _hasHydrated, ...persistedState } = state;
-
-        // Explicitly handle the wallet info to ensure we don't store providers
-        return {
-          ...persistedState,
-          connectedWallets: state.connectedWallets.map((wallet) => ({
-            type: wallet.type,
-            name: wallet.name,
-            address: wallet.address,
-            chainId: wallet.chainId,
-          })),
-          activeWallet: state.activeWallet
-            ? {
-                type: state.activeWallet.type,
-                name: state.activeWallet.name,
-                address: state.activeWallet.address,
-                chainId: state.activeWallet.chainId,
-              }
-            : null,
-        } as PersistedState;
-      },
-      // Add onRehydrateStorage to track hydration state
-      onRehydrateStorage: () => (state) => {
-        if (state) {
-          set({ _hasHydrated: true } as unknown as Partial<T>);
-        }
-      },
-    };
-
-    // Create the persist store with the config
-    return persist(config, persistOptions)(set, get, api);
-  };
-
-// Create the store with our custom middleware
-const useWeb3Store = create<ExtendedWeb3StoreState>()(
-  createPersistMiddleware((set) => ({
-    connectedWallets: [],
-    activeWallet: null,
-    _hasHydrated: false,
-
-    // Chain selection state
-    sourceChain: defaultChain,
-    destinationChain: defaultChain,
-
-    // Wallet actions
-    addWallet: (wallet: WalletInfo) => {
-      // Create a new wallet object without the provider
-      const walletForStorage = {
-        type: wallet.type,
-        name: wallet.name,
-        address: wallet.address,
-        chainId: wallet.chainId,
-      };
-
-      set((state) => {
-        const existingWalletIndex = state.connectedWallets.findIndex(
-          (w) => w.type === wallet.type,
-        );
-        let newWallets: Array<Omit<WalletInfo, "provider">>;
-
-        if (existingWalletIndex >= 0) {
-          newWallets = [...state.connectedWallets];
-          newWallets[existingWalletIndex] = walletForStorage;
-        } else {
-          newWallets = [...state.connectedWallets, walletForStorage];
-        }
-
-        return {
-          connectedWallets: newWallets,
-          activeWallet: state.activeWallet || walletForStorage,
+      // Wallet actions
+      addWallet: (wallet: WalletInfo) => {
+        // Create a new wallet object without the provider
+        const walletForStorage = {
+          type: wallet.type,
+          name: wallet.name,
+          address: wallet.address,
+          chainId: wallet.chainId,
         };
-      });
-    },
 
-    removeWallet: (walletType: WalletType) => {
-      set((state) => ({
-        connectedWallets: state.connectedWallets.filter(
-          (w) => w.type !== walletType,
-        ),
-        activeWallet:
-          state.activeWallet?.type === walletType
-            ? state.connectedWallets.find((w) => w.type !== walletType) || null
-            : state.activeWallet,
-      }));
-    },
+        set((state) => {
+          const existingWalletIndex = state.connectedWallets.findIndex(
+            (w) => w.type === wallet.type,
+          );
+          let newWallets: Array<Omit<WalletInfo, "provider">>;
 
-    setActiveWallet: (walletType: WalletType) => {
-      set((state) => ({
-        activeWallet:
-          state.connectedWallets.find((w) => w.type === walletType) ||
-          state.activeWallet,
-      }));
-    },
+          if (existingWalletIndex >= 0) {
+            newWallets = [...state.connectedWallets];
+            newWallets[existingWalletIndex] = walletForStorage;
+          } else {
+            newWallets = [...state.connectedWallets, walletForStorage];
+          }
 
-    updateWalletAddress: (walletType: WalletType, address: string) => {
-      set((state) => ({
-        connectedWallets: state.connectedWallets.map((wallet) =>
-          wallet.type === walletType ? { ...wallet, address } : wallet,
-        ),
-        activeWallet:
-          state.activeWallet?.type === walletType
-            ? { ...state.activeWallet, address }
-            : state.activeWallet,
-      }));
-    },
+          return {
+            connectedWallets: newWallets,
+            activeWallet: state.activeWallet || walletForStorage,
+          };
+        });
+      },
 
-    updateWalletChainId: (walletType: WalletType, chainId: number) => {
-      set((state) => ({
-        connectedWallets: state.connectedWallets.map((wallet) =>
-          wallet.type === walletType ? { ...wallet, chainId } : wallet,
-        ),
-        activeWallet:
-          state.activeWallet?.type === walletType
-            ? { ...state.activeWallet, chainId }
-            : state.activeWallet,
-      }));
-    },
+      removeWallet: (walletType: WalletType) => {
+        set((state) => ({
+          connectedWallets: state.connectedWallets.filter(
+            (w) => w.type !== walletType,
+          ),
+          activeWallet:
+            state.activeWallet?.type === walletType
+              ? state.connectedWallets.find((w) => w.type !== walletType) ||
+                null
+              : state.activeWallet,
+        }));
+      },
 
-    disconnectAll: () => {
-      set({
-        connectedWallets: [],
-        activeWallet: null,
-      });
-    },
+      setActiveWallet: (walletType: WalletType) => {
+        set((state) => ({
+          activeWallet:
+            state.connectedWallets.find((w) => w.type === walletType) ||
+            state.activeWallet,
+        }));
+      },
 
-    // Chain selection actions
-    setSourceChain: (chain: Chain) => {
-      set((state) => ({
-        sourceChain: chain,
-        // Optionally prevent same source and destination
-        destinationChain:
-          state.destinationChain.id === chain.id
-            ? state.sourceChain
-            : state.destinationChain,
-      }));
-    },
+      updateWalletAddress: (walletType: WalletType, address: string) => {
+        set((state) => ({
+          connectedWallets: state.connectedWallets.map((wallet) =>
+            wallet.type === walletType ? { ...wallet, address } : wallet,
+          ),
+          activeWallet:
+            state.activeWallet?.type === walletType
+              ? { ...state.activeWallet, address }
+              : state.activeWallet,
+        }));
+      },
 
-    setDestinationChain: (chain: Chain) => {
-      set((state) => ({
-        destinationChain: chain,
-        // Optionally prevent same source and destination
-        sourceChain:
-          state.sourceChain.id === chain.id
-            ? state.destinationChain
-            : state.sourceChain,
-      }));
-    },
+      updateWalletChainId: (walletType: WalletType, chainId: number) => {
+        set((state) => ({
+          connectedWallets: state.connectedWallets.map((wallet) =>
+            wallet.type === walletType ? { ...wallet, chainId } : wallet,
+          ),
+          activeWallet:
+            state.activeWallet?.type === walletType
+              ? { ...state.activeWallet, chainId }
+              : state.activeWallet,
+        }));
+      },
 
-    swapChains: () => {
-      set((state) => ({
-        sourceChain: state.destinationChain,
-        destinationChain: state.sourceChain,
-      }));
+      disconnectAll: () => {
+        set({
+          connectedWallets: [],
+          activeWallet: null,
+        });
+      },
+
+      // Chain selection actions
+      setSourceChain: (chain: Chain) => {
+        set((state) => ({
+          sourceChain: chain,
+          // Optionally prevent same source and destination
+          destinationChain:
+            state.destinationChain.id === chain.id
+              ? state.sourceChain
+              : state.destinationChain,
+        }));
+      },
+
+      setDestinationChain: (chain: Chain) => {
+        set((state) => ({
+          destinationChain: chain,
+          // Optionally prevent same source and destination
+          sourceChain:
+            state.sourceChain.id === chain.id
+              ? state.destinationChain
+              : state.sourceChain,
+        }));
+      },
+
+      swapChains: () => {
+        set((state) => ({
+          sourceChain: state.destinationChain,
+          destinationChain: state.sourceChain,
+        }));
+      },
+    }),
+    {
+      name: "altverse-storage-web3",
+      storage: createJSONStorage(() => {
+        // Handle SSR case
+        if (typeof window === "undefined") {
+          return {
+            getItem: () => Promise.resolve(null),
+            setItem: () => Promise.resolve(),
+            removeItem: () => Promise.resolve(),
+          };
+        }
+        return localStorage;
+      }),
+      partialize: (state) => ({
+        // Only persist what we need and ensure we don't store providers
+        connectedWallets: state.connectedWallets.map((wallet) => ({
+          type: wallet.type,
+          name: wallet.name,
+          address: wallet.address,
+          chainId: wallet.chainId,
+        })),
+        activeWallet: state.activeWallet
+          ? {
+              type: state.activeWallet.type,
+              name: state.activeWallet.name,
+              address: state.activeWallet.address,
+              chainId: state.activeWallet.chainId,
+            }
+          : null,
+        sourceChain: state.sourceChain,
+        destinationChain: state.destinationChain,
+      }),
     },
-  })),
+  ),
 );
 
-// Create a hook to check if the store has hydrated
-export const useStoreHydration = (): boolean => {
-  const isHydrated = useWeb3Store((state) => !!state._hasHydrated);
-
-  // Add a debug message to see when hydration is complete
-  React.useEffect(() => {
-    if (isHydrated) {
-      console.log("Zustand store has hydrated from localStorage");
-    }
-  }, [isHydrated]);
-
-  return isHydrated;
-};
-
-// Existing hook
+// Utility hooks for chain selection
 export const useCurrentChainId = (): number | null => {
   return useWeb3Store((state) => state.activeWallet?.chainId ?? null);
 };
 
-// New hooks for chain selection
 export const useSourceChain = (): Chain => {
   return useWeb3Store((state) => state.sourceChain);
 };

--- a/site/src/store/web3Store.ts
+++ b/site/src/store/web3Store.ts
@@ -1,121 +1,235 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
-import { WalletInfo, Web3StoreState, WalletType } from "@/types/wallet";
+import {
+  persist,
+  createJSONStorage,
+  PersistOptions,
+  StateStorage,
+} from "zustand/middleware";
+import { StateCreator, StoreApi } from "zustand";
+import { WalletInfo, Web3StoreState, WalletType } from "@/types/web3";
+import { Chain, defaultChain } from "@/config/chains";
+import React from "react";
 
-const useWeb3Store = create<Web3StoreState>()(
-  persist(
-    (set) => ({
-      connectedWallets: [],
-      activeWallet: null,
+// Extend the store state to include hydration status
+interface ExtendedWeb3StoreState extends Web3StoreState {
+  // Used by useStoreHydration hook to track hydration status
+  _hasHydrated?: boolean;
+}
 
-      addWallet: (wallet: WalletInfo) => {
-        // Create a new wallet object without the provider
-        const walletForStorage = {
-          type: wallet.type,
-          name: wallet.name,
-          address: wallet.address,
-          chainId: wallet.chainId,
-        };
+// Helper type for the persisted state - everything except _hasHydrated
+type PersistedState = Omit<ExtendedWeb3StoreState, "_hasHydrated">;
 
-        set((state) => {
-          const existingWalletIndex = state.connectedWallets.findIndex(
-            (w) => w.type === wallet.type,
-          );
-          let newWallets: Omit<WalletInfo, "provider">[];
+// Using Zustand's built-in types instead of defining our own
 
-          if (existingWalletIndex >= 0) {
-            newWallets = [...state.connectedWallets];
-            newWallets[existingWalletIndex] = walletForStorage;
-          } else {
-            newWallets = [...state.connectedWallets, walletForStorage];
-          }
+// Create a custom version of persist middleware that handles SSR/hydration
+const createPersistMiddleware =
+  <T extends ExtendedWeb3StoreState>(config: StateCreator<T, [], []>) =>
+  (
+    set: StoreApi<T>["setState"],
+    get: StoreApi<T>["getState"],
+    api: StoreApi<T>,
+  ) => {
+    const isSSR = typeof window === "undefined";
 
-          return {
-            connectedWallets: newWallets,
-            activeWallet: state.activeWallet || walletForStorage,
-          };
-        });
-      },
-
-      removeWallet: (walletType: WalletType) => {
-        set((state) => ({
-          connectedWallets: state.connectedWallets.filter(
-            (w) => w.type !== walletType,
-          ),
-          activeWallet:
-            state.activeWallet?.type === walletType
-              ? state.connectedWallets.find((w) => w.type !== walletType) ||
-                null
-              : state.activeWallet,
-        }));
-      },
-
-      setActiveWallet: (walletType: WalletType) => {
-        set((state) => ({
-          activeWallet:
-            state.connectedWallets.find((w) => w.type === walletType) ||
-            state.activeWallet,
-        }));
-      },
-
-      updateWalletAddress: (walletType: WalletType, address: string) => {
-        set((state) => ({
-          connectedWallets: state.connectedWallets.map((wallet) =>
-            wallet.type === walletType ? { ...wallet, address } : wallet,
-          ),
-          activeWallet:
-            state.activeWallet?.type === walletType
-              ? { ...state.activeWallet, address }
-              : state.activeWallet,
-        }));
-      },
-
-      updateWalletChainId: (walletType: WalletType, chainId: number) => {
-        set((state) => ({
-          connectedWallets: state.connectedWallets.map((wallet) =>
-            wallet.type === walletType ? { ...wallet, chainId } : wallet,
-          ),
-          activeWallet:
-            state.activeWallet?.type === walletType
-              ? { ...state.activeWallet, chainId }
-              : state.activeWallet,
-        }));
-      },
-
-      disconnectAll: () => {
-        set({
-          connectedWallets: [],
-          activeWallet: null,
-        });
-      },
-    }),
-    {
+    // Configure persistence options
+    const persistOptions: PersistOptions<T, PersistedState> = {
       name: "altverse-storage-web3",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() =>
+        isSSR
+          ? ({
+              getItem: () => Promise.resolve(null),
+              setItem: () => Promise.resolve(),
+              removeItem: () => Promise.resolve(),
+            } as StateStorage)
+          : localStorage,
+      ),
       version: 1,
-      partialize: (state) => ({
-        // Only persist these fields, and ensure we're not storing the provider
-        connectedWallets: state.connectedWallets.map((wallet) => ({
-          type: wallet.type,
-          name: wallet.name,
-          address: wallet.address,
-          chainId: wallet.chainId,
-        })),
-        activeWallet: state.activeWallet
-          ? {
-              type: state.activeWallet.type,
-              name: state.activeWallet.name,
-              address: state.activeWallet.address,
-              chainId: state.activeWallet.chainId,
-            }
-          : null,
-      }),
+      partialize: (state): PersistedState => {
+        // Create a shallow copy of state without _hasHydrated
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { _hasHydrated, ...persistedState } = state;
+
+        // Explicitly handle the wallet info to ensure we don't store providers
+        return {
+          ...persistedState,
+          connectedWallets: state.connectedWallets.map((wallet) => ({
+            type: wallet.type,
+            name: wallet.name,
+            address: wallet.address,
+            chainId: wallet.chainId,
+          })),
+          activeWallet: state.activeWallet
+            ? {
+                type: state.activeWallet.type,
+                name: state.activeWallet.name,
+                address: state.activeWallet.address,
+                chainId: state.activeWallet.chainId,
+              }
+            : null,
+        } as PersistedState;
+      },
+      // Add onRehydrateStorage to track hydration state
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          set({ _hasHydrated: true } as unknown as Partial<T>);
+        }
+      },
+    };
+
+    // Create the persist store with the config
+    return persist(config, persistOptions)(set, get, api);
+  };
+
+// Create the store with our custom middleware
+const useWeb3Store = create<ExtendedWeb3StoreState>()(
+  createPersistMiddleware((set) => ({
+    connectedWallets: [],
+    activeWallet: null,
+    _hasHydrated: false,
+
+    // Chain selection state
+    sourceChain: defaultChain,
+    destinationChain: defaultChain,
+
+    // Wallet actions
+    addWallet: (wallet: WalletInfo) => {
+      // Create a new wallet object without the provider
+      const walletForStorage = {
+        type: wallet.type,
+        name: wallet.name,
+        address: wallet.address,
+        chainId: wallet.chainId,
+      };
+
+      set((state) => {
+        const existingWalletIndex = state.connectedWallets.findIndex(
+          (w) => w.type === wallet.type,
+        );
+        let newWallets: Array<Omit<WalletInfo, "provider">>;
+
+        if (existingWalletIndex >= 0) {
+          newWallets = [...state.connectedWallets];
+          newWallets[existingWalletIndex] = walletForStorage;
+        } else {
+          newWallets = [...state.connectedWallets, walletForStorage];
+        }
+
+        return {
+          connectedWallets: newWallets,
+          activeWallet: state.activeWallet || walletForStorage,
+        };
+      });
     },
-  ),
+
+    removeWallet: (walletType: WalletType) => {
+      set((state) => ({
+        connectedWallets: state.connectedWallets.filter(
+          (w) => w.type !== walletType,
+        ),
+        activeWallet:
+          state.activeWallet?.type === walletType
+            ? state.connectedWallets.find((w) => w.type !== walletType) || null
+            : state.activeWallet,
+      }));
+    },
+
+    setActiveWallet: (walletType: WalletType) => {
+      set((state) => ({
+        activeWallet:
+          state.connectedWallets.find((w) => w.type === walletType) ||
+          state.activeWallet,
+      }));
+    },
+
+    updateWalletAddress: (walletType: WalletType, address: string) => {
+      set((state) => ({
+        connectedWallets: state.connectedWallets.map((wallet) =>
+          wallet.type === walletType ? { ...wallet, address } : wallet,
+        ),
+        activeWallet:
+          state.activeWallet?.type === walletType
+            ? { ...state.activeWallet, address }
+            : state.activeWallet,
+      }));
+    },
+
+    updateWalletChainId: (walletType: WalletType, chainId: number) => {
+      set((state) => ({
+        connectedWallets: state.connectedWallets.map((wallet) =>
+          wallet.type === walletType ? { ...wallet, chainId } : wallet,
+        ),
+        activeWallet:
+          state.activeWallet?.type === walletType
+            ? { ...state.activeWallet, chainId }
+            : state.activeWallet,
+      }));
+    },
+
+    disconnectAll: () => {
+      set({
+        connectedWallets: [],
+        activeWallet: null,
+      });
+    },
+
+    // Chain selection actions
+    setSourceChain: (chain: Chain) => {
+      set((state) => ({
+        sourceChain: chain,
+        // Optionally prevent same source and destination
+        destinationChain:
+          state.destinationChain.id === chain.id
+            ? state.sourceChain
+            : state.destinationChain,
+      }));
+    },
+
+    setDestinationChain: (chain: Chain) => {
+      set((state) => ({
+        destinationChain: chain,
+        // Optionally prevent same source and destination
+        sourceChain:
+          state.sourceChain.id === chain.id
+            ? state.destinationChain
+            : state.sourceChain,
+      }));
+    },
+
+    swapChains: () => {
+      set((state) => ({
+        sourceChain: state.destinationChain,
+        destinationChain: state.sourceChain,
+      }));
+    },
+  })),
 );
 
-export const useCurrentChainId = () => {
+// Create a hook to check if the store has hydrated
+export const useStoreHydration = (): boolean => {
+  const isHydrated = useWeb3Store((state) => !!state._hasHydrated);
+
+  // Add a debug message to see when hydration is complete
+  React.useEffect(() => {
+    if (isHydrated) {
+      console.log("Zustand store has hydrated from localStorage");
+    }
+  }, [isHydrated]);
+
+  return isHydrated;
+};
+
+// Existing hook
+export const useCurrentChainId = (): number | null => {
   return useWeb3Store((state) => state.activeWallet?.chainId ?? null);
+};
+
+// New hooks for chain selection
+export const useSourceChain = (): Chain => {
+  return useWeb3Store((state) => state.sourceChain);
+};
+
+export const useDestinationChain = (): Chain => {
+  return useWeb3Store((state) => state.destinationChain);
 };
 
 export default useWeb3Store;

--- a/site/src/types/web3.ts
+++ b/site/src/types/web3.ts
@@ -1,3 +1,5 @@
+import { Chain } from "@/config/chains";
+
 export interface WalletInfo {
   type: WalletType; // Static Enum to type/identify the wallet
   name: string; // human-readable name of the wallet e.g. "MetaMask"
@@ -16,6 +18,8 @@ export interface Web3StoreState {
   // Connected wallets
   connectedWallets: WalletInfo[];
   activeWallet: WalletInfo | null;
+  sourceChain: Chain;
+  destinationChain: Chain;
 
   // Actions
   addWallet: (wallet: WalletInfo) => void;
@@ -24,4 +28,7 @@ export interface Web3StoreState {
   disconnectAll: () => void; // in case a user wants to completely log out
   updateWalletChainId: (walletType: WalletType, chainId: number) => void; // allows chain switching on individual wallet connections
   updateWalletAddress: (walletType: WalletType, address: string) => void; // allows user to seamlessly switch addresses
+  setSourceChain: (chain: Chain) => void;
+  setDestinationChain: (chain: Chain) => void;
+  swapChains: () => void;
 }

--- a/site/src/utils/chainMethods.ts
+++ b/site/src/utils/chainMethods.ts
@@ -1,0 +1,126 @@
+import { Chain, chains } from "@/config/chains";
+import useWeb3Store from "@/store/web3Store";
+
+// Global hydration tracker
+let globalHydrated = false;
+
+/**
+ * Handles chain selection for source or destination chains
+ * Ensures no duplicate chains are selected
+ * @param chain The chain being selected
+ * @param type Either "source" or "destination"
+ */
+export function handleChainChange(
+  chain: Chain,
+  type: "source" | "destination",
+): void {
+  const store = useWeb3Store.getState();
+  const isSource = type === "source";
+
+  // Get current chains
+  const sourceChain = store.sourceChain;
+  const destinationChain = store.destinationChain;
+
+  // Get the appropriate setters
+  const setSourceChain = store.setSourceChain;
+  const setDestinationChain = store.setDestinationChain;
+
+  // Determine which chains we're working with
+  const oppositeChain = isSource ? destinationChain : sourceChain;
+  const setCurrentChain = isSource ? setSourceChain : setDestinationChain;
+  const setOppositeChain = isSource ? setDestinationChain : setSourceChain;
+
+  // Log the change
+  console.log(
+    `${isSource ? "Source" : "Destination"} chain changed to:`,
+    chain.name,
+  );
+
+  // Update the current chain
+  setCurrentChain(chain);
+
+  // If same chain selected, find a different one for the opposite side
+  if (chain.id === oppositeChain.id) {
+    const differentChain = Object.values(chains).find((c) => c.id !== chain.id);
+    if (differentChain) {
+      setOppositeChain(differentChain);
+    }
+  }
+}
+
+/**
+ * Swap source and destination chains
+ */
+export function swapChains(): void {
+  const store = useWeb3Store.getState();
+  store.swapChains();
+}
+
+/**
+ * Format a chain pair for display
+ * @param sourceChain The source chain
+ * @param destinationChain The destination chain
+ * @returns Formatted string like "Ethereum → Polygon"
+ */
+export function formatChainRoute(
+  sourceChain: Chain,
+  destinationChain: Chain,
+): string {
+  return `${sourceChain.name} → ${destinationChain.name}`;
+}
+
+/**
+ * Get a different chain from the one provided
+ * Useful for ensuring source and destination are different
+ * @param currentChain The chain to avoid
+ * @returns A different chain
+ */
+export function getDifferentChain(currentChain: Chain): Chain | undefined {
+  return Object.values(chains).find((c) => c.id !== currentChain.id);
+}
+
+/**
+ * Check if the store has hydrated from localStorage
+ * This uses a global variable to track hydration status across page navigations
+ * @returns Boolean indicating if hydration is complete
+ */
+export function isStoreHydrated(): boolean {
+  // If we've already detected hydration, return true immediately
+  if (globalHydrated) return true;
+
+  // Otherwise check the store
+  const store = useWeb3Store.getState();
+  const currentlyHydrated = !!store._hasHydrated;
+
+  // If hydrated, update the global flag for future checks
+  if (currentlyHydrated) {
+    globalHydrated = true;
+    console.log("Zustand store hydration detected and cached globally");
+  }
+
+  return currentlyHydrated;
+}
+
+/**
+ * Hook to check and wait for hydration
+ * Use this in components to track hydration status
+ * @returns A function that checks hydration status
+ */
+export function useHydrationCheck(): () => Promise<boolean> {
+  return async () => {
+    // If already hydrated, return immediately
+    if (globalHydrated) return true;
+
+    // Otherwise check and wait if needed
+    return new Promise<boolean>((resolve) => {
+      const checkHydration = () => {
+        if (isStoreHydrated()) {
+          resolve(true);
+        } else {
+          setTimeout(checkHydration, 50);
+        }
+      };
+      checkHydration();
+    });
+  };
+}

--- a/site/src/utils/chainMethods.ts
+++ b/site/src/utils/chainMethods.ts
@@ -1,9 +1,6 @@
 import { Chain, chains } from "@/config/chains";
 import useWeb3Store from "@/store/web3Store";
 
-// Global hydration tracker
-let globalHydrated = false;
-
 /**
  * Handles chain selection for source or destination chains
  * Ensures no duplicate chains are selected
@@ -77,50 +74,4 @@ export function formatChainRoute(
  */
 export function getDifferentChain(currentChain: Chain): Chain | undefined {
   return Object.values(chains).find((c) => c.id !== currentChain.id);
-}
-
-/**
- * Check if the store has hydrated from localStorage
- * This uses a global variable to track hydration status across page navigations
- * @returns Boolean indicating if hydration is complete
- */
-export function isStoreHydrated(): boolean {
-  // If we've already detected hydration, return true immediately
-  if (globalHydrated) return true;
-
-  // Otherwise check the store
-  const store = useWeb3Store.getState();
-  const currentlyHydrated = !!store._hasHydrated;
-
-  // If hydrated, update the global flag for future checks
-  if (currentlyHydrated) {
-    globalHydrated = true;
-    console.log("Zustand store hydration detected and cached globally");
-  }
-
-  return currentlyHydrated;
-}
-
-/**
- * Hook to check and wait for hydration
- * Use this in components to track hydration status
- * @returns A function that checks hydration status
- */
-export function useHydrationCheck(): () => Promise<boolean> {
-  return async () => {
-    // If already hydrated, return immediately
-    if (globalHydrated) return true;
-
-    // Otherwise check and wait if needed
-    return new Promise<boolean>((resolve) => {
-      const checkHydration = () => {
-        if (isStoreHydrated()) {
-          resolve(true);
-        } else {
-          setTimeout(checkHydration, 50);
-        }
-      };
-      checkHydration();
-    });
-  };
 }

--- a/site/src/utils/walletMethods.ts
+++ b/site/src/utils/walletMethods.ts
@@ -1,4 +1,4 @@
-import { WalletInfo, WalletType } from "@/types/wallet";
+import { WalletInfo, WalletType } from "@/types/web3";
 
 import useWeb3Store from "@/store/web3Store";
 


### PR DESCRIPTION
Chain selection is now stored in zustand, persisting between browser sessions & page refreshes.

Changes:
- Added `chainMethods.ts`, a file for reusable chain methods (similar to `wallletMethods.ts`)
- Updated web3Store to include chain selections
- Renamed `/types/wallet.ts` to `/types/web3.ts` (hence the large number of file changes, apologies)

**To test, please try changing the source/destination chain on both swap and bridge and test persistence by refreshing the page, closing the tab/reopening, etc.**